### PR TITLE
fix NESeq.intersperse

### DIFF
--- a/src/Data/Sequence/NonEmpty.hs
+++ b/src/Data/Sequence/NonEmpty.hs
@@ -957,7 +957,9 @@ mapReverse f (x :<|| xs) = fmap f (Seq.reverse xs) :||> f x
 -- intersperse a (fromList [x,y,z]) = fromList [x,a,y,a,z]
 -- @
 intersperse :: a -> NESeq a -> NESeq a
-intersperse z (x :<|| xs) = x :<|| (z Seq.<| Seq.intersperse z xs)
+intersperse z nes@(x :<|| xs) = case xs of
+  _ Seq.:<| _ -> x :<|| (z Seq.<| Seq.intersperse z xs)
+  Seq.Empty -> nes
 {-# INLINE intersperse #-}
 
 -- | \( O(\min(n_1,n_2,n_3)) \).  'zip3' takes three sequences and returns a


### PR DESCRIPTION
Previously
```haskell
(Seq.intersperse "," (Seq.singleton "a")) == (NESeq.toSeq (NESeq.intersperse "," (NESeq.singleton ("a" :: String))))
> False
```
which I don't think is right since it violates
```haskell
intersperse a (singleton x) = singleton x
```
This fix just checks if the `NESeq` has more than 1 element or not and does nothing if there is 1 element.

I don't know how to make sure the property test generates a singleton `NESeq`. I'm actually kinda surprised that the generator didn't try that.