### PR TITLE
Support building with Stackage LTS-18/GHC 9

### DIFF
--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -562,10 +562,17 @@ instance Traversable NEIntMap where
 -- elements in order of ascending keys, while 'IntMap' traverses positive
 -- keys first, then negative keys.
 instance Foldable1 NEIntMap where
+#if MIN_VERSION_base(4,11,0)
+    fold1 (NEIntMap _ v m) = maybe v (v <>)
+                           . F.foldMap Just
+                           . M.elems
+                           $ m
+#else
     fold1 (NEIntMap _ v m) = option v (v <>)
                            . F.foldMap (Option . Just)
                            . M.elems
                            $ m
+#endif
     {-# INLINE fold1 #-}
     foldMap1 f = foldMapWithKey (const f)
     {-# INLINE foldMap1 #-}

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -181,7 +181,7 @@ instance Data a => Data (NEIntMap a) where
     1 -> k (z fromList)
     _ -> error "gunfold"
   dataTypeOf _   = intMapDataType
-  dataCast1      = gcast1
+  dataCast1 f    = gcast1 f
 
 fromListConstr :: Constr
 fromListConstr = mkConstr intMapDataType "fromList" [] Prefix

--- a/src/Data/Map/NonEmpty/Internal.hs
+++ b/src/Data/Map/NonEmpty/Internal.hs
@@ -182,7 +182,7 @@ instance (Data k, Data a, Ord k) => Data (NEMap k a) where
       1 -> k (z fromList)
       _ -> error "gunfold"
     dataTypeOf _   = mapDataType
-    dataCast2      = gcast2
+    dataCast2 f    = gcast2 f
 
 fromListConstr :: Constr
 fromListConstr = mkConstr mapDataType "fromList" [] Prefix

--- a/src/Data/Map/NonEmpty/Internal.hs
+++ b/src/Data/Map/NonEmpty/Internal.hs
@@ -275,9 +275,15 @@ foldMapWithKey
     => (k -> a -> m)
     -> NEMap k a
     -> m
+#if MIN_VERSION_base(4,11,0)
+foldMapWithKey f (NEMap k0 v m) = maybe (f k0 v) (f k0 v <>)
+                                . M.foldMapWithKey (\k -> Just . f k)
+                                $ m
+#else
 foldMapWithKey f (NEMap k0 v m) = option (f k0 v) (f k0 v <>)
                                 . M.foldMapWithKey (\k -> Option . Just . f k)
                                 $ m
+#endif
 {-# INLINE foldMapWithKey #-}
 
 -- | /O(n)/. Map a function over all values in the map.
@@ -545,9 +551,15 @@ instance Traversable (NEMap k) where
 
 -- | Traverses elements in order of ascending keys
 instance Foldable1 (NEMap k) where
+#if MIN_VERSION_base(4,11,0)
+    fold1 (NEMap _ v m) = maybe v (v <>)
+                        . F.foldMap Just
+                        $ m
+#else
     fold1 (NEMap _ v m) = option v (v <>)
                         . F.foldMap (Option . Just)
                         $ m
+#endif
     {-# INLINE fold1 #-}
     foldMap1 f = foldMapWithKey (const f)
     {-# INLINE foldMap1 #-}

--- a/src/Data/Sequence/NonEmpty/Internal.hs
+++ b/src/Data/Sequence/NonEmpty/Internal.hs
@@ -317,9 +317,15 @@ map f (x :<|| xs) = f x :<|| fmap f xs
 -- a folding function that also depends on the element's index, and applies
 -- it to every element in the sequence.
 foldMapWithIndex :: Semigroup m => (Int -> a -> m) -> NESeq a -> m
+#if MIN_VERSION_base(4,11,0)
+foldMapWithIndex f (x :<|| xs) = maybe (f 0 x) (f 0 x <>)
+                               . Seq.foldMapWithIndex (\i -> Just . f (i + 1))
+                               $ xs
+#else
 foldMapWithIndex f (x :<|| xs) = option (f 0 x) (f 0 x <>)
                                . Seq.foldMapWithIndex (\i -> Option . Just . f (i + 1))
                                $ xs
+#endif
 {-# INLINE foldMapWithIndex #-}
 
 -- | /O(n)/. 'traverseWithIndex1' is a version of 'traverse1' that also
@@ -467,9 +473,15 @@ instance Foldable NESeq where
     {-# INLINE length #-}
 
 instance Foldable1 NESeq where
+#if MIN_VERSION_base(4,11,0)
+    fold1 (x :<|| xs) = maybe x (x <>)
+                      . F.foldMap Just
+                      $ xs
+#else
     fold1 (x :<|| xs) = option x (x <>)
                       . F.foldMap (Option . Just)
                       $ xs
+#endif
     {-# INLINE fold1 #-}
     foldMap1 f = foldMapWithIndex (const f)
     {-# INLINE foldMap1 #-}

--- a/src/Data/Sequence/NonEmpty/Internal.hs
+++ b/src/Data/Sequence/NonEmpty/Internal.hs
@@ -185,7 +185,7 @@ instance Data a => Data (NESeq a) where
     gunfold k z _   = k (k (z (:<||)))
     toConstr _      = consConstr
     dataTypeOf _    = seqDataType
-    dataCast1       = gcast1
+    dataCast1 f     = gcast1 f
 
 consConstr :: Constr
 consConstr  = mkConstr seqDataType ":<||" [] Infix

--- a/src/Data/Set/NonEmpty/Internal.hs
+++ b/src/Data/Set/NonEmpty/Internal.hs
@@ -153,7 +153,7 @@ instance (Data a, Ord a) => Data (NESet a) where
     1 -> k (z fromList)
     _ -> error "gunfold"
   dataTypeOf _   = setDataType
-  dataCast1      = gcast1
+  dataCast1 f    = gcast1 f
 
 fromListConstr :: Constr
 fromListConstr = mkConstr setDataType "fromList" [] Prefix

--- a/src/Data/Set/NonEmpty/Internal.hs
+++ b/src/Data/Set/NonEmpty/Internal.hs
@@ -377,6 +377,17 @@ instance Foldable NESet where
 
 -- | Traverses elements in ascending order
 instance Foldable1 NESet where
+#if MIN_VERSION_base(4,11,0)
+    fold1 (NESet x s) = maybe x (x <>)
+                      . F.foldMap Just
+                      $ s
+    {-# INLINE fold1 #-}
+    -- TODO: benchmark against maxView-based method
+    foldMap1 f (NESet x s) = maybe (f x) (f x <>)
+                           . F.foldMap (Just . f)
+                           $ s
+    {-# INLINE foldMap1 #-}
+#else
     fold1 (NESet x s) = option x (x <>)
                       . F.foldMap (Option . Just)
                       $ s
@@ -386,6 +397,7 @@ instance Foldable1 NESet where
                            . F.foldMap (Option . Just . f)
                            $ s
     {-# INLINE foldMap1 #-}
+#endif
     toNonEmpty = toList
     {-# INLINE toNonEmpty #-}
 


### PR DESCRIPTION
Looks like the "simplified subsumption" changes in GHC 9 broke the Data instances in this package. They weren't broken in containers, so I fixed them by eta expanding to match. I also added CPP gates for code using Option which is deprecated. This branch compiled with no errors and no warnings for me using lts-11 (pre-monoid semigroup fix), lts-13, lts-18, and nightly.