### PR TITLE
Support `containers-0.8`.

### DIFF
--- a/nonempty-containers.cabal
+++ b/nonempty-containers.cabal
@@ -54,7 +54,7 @@ library
       aeson
     , base             >=4.9   && <5
     , comonad
-    , containers       >=0.5.9
+    , containers       >=0.6.3.1 && <0.9
     , deepseq
     , invariant
     , nonempty-vector
@@ -84,7 +84,7 @@ test-suite nonempty-containers-test
   build-depends:
       base                 >=4.9   && <5
     , comonad
-    , containers           >=0.5.9
+    , containers           >=0.6.3.1 && <0.9
     , hedgehog             >=1.0
     , hedgehog-fn          >=1.0
     , invariant

--- a/src/Data/IntMap/NonEmpty.hs
+++ b/src/Data/IntMap/NonEmpty.hs
@@ -968,7 +968,7 @@ lookupLT k (NEIntMap k0 v m) = case compare k k0 of
 lookupGT :: Key -> NEIntMap a -> Maybe (Key, a)
 lookupGT k (NEIntMap k0 v m) = case compare k k0 of
   LT -> Just (k0, v)
-  EQ -> lookupMinMap m
+  EQ -> M.lookupMin m
   GT -> M.lookupGT k m
 {-# INLINE lookupGT #-}
 
@@ -1802,7 +1802,7 @@ findMin (NEIntMap k v _) = (k, v)
 --
 -- > findMax (fromList ((5,"a") :| [(3,"b")])) == (5,"a")
 findMax :: NEIntMap a -> (Key, a)
-findMax (NEIntMap k v m) = fromMaybe (k, v) . lookupMaxMap $ m
+findMax (NEIntMap k v m) = fromMaybe (k, v) . M.lookupMax $ m
 {-# INLINE findMax #-}
 
 -- | /O(1)/. Delete the minimal key. Returns a potentially empty map

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -716,11 +716,7 @@ insertMaxMap = M.insert
 -- | /O(n)/. A fixed version of 'Data.IntMap.traverseWithKey' that
 -- traverses items in ascending order of keys.
 traverseMapWithKey :: Applicative t => (Key -> a -> t b) -> IntMap a -> t (IntMap b)
-traverseMapWithKey f = go
-  where
-    go Nil = pure Nil
-    go (Tip k v) = Tip k <$> f k v
-    go (Bin p m l r) = liftA2 (flip (Bin p m)) (go r) (go l)
+traverseMapWithKey = M.traverseWithKey
 {-# INLINE traverseMapWithKey #-}
 
 -- ---------------------------------------------

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -46,7 +46,6 @@ module Data.IntMap.NonEmpty.Internal (
   traverseWithKey,
   traverseWithKey1,
   foldMapWithKey,
-  traverseMapWithKey,
 
   -- * Unsafe IntMap Functions
   insertMinMap,
@@ -409,7 +408,7 @@ traverseWithKey ::
 traverseWithKey f (NEIntMap k v m0) =
   NEIntMap k
     <$> f k v
-    <*> traverseMapWithKey f m0
+    <*> M.traverseWithKey f m0
 {-# INLINE traverseWithKey #-}
 
 -- | /O(n)/.
@@ -434,7 +433,7 @@ traverseWithKey1 f (NEIntMap k0 v m0) = case runMaybeApply m1 of
   Left m2 -> NEIntMap k0 <$> f k0 v <.> m2
   Right m2 -> flip (NEIntMap k0) m2 <$> f k0 v
   where
-    m1 = traverseMapWithKey (\k -> MaybeApply . Left . f k) m0
+    m1 = M.traverseWithKey (\k -> MaybeApply . Left . f k) m0
 {-# INLINEABLE traverseWithKey1 #-}
 
 -- | /O(n)/. Convert the map to a non-empty list of key\/value pairs.
@@ -712,12 +711,6 @@ insertMinMap = M.insert
 insertMaxMap :: Key -> a -> IntMap a -> IntMap a
 insertMaxMap = M.insert
 {-# INLINEABLE insertMaxMap #-}
-
--- | /O(n)/. A fixed version of 'Data.IntMap.traverseWithKey' that
--- traverses items in ascending order of keys.
-traverseMapWithKey :: Applicative t => (Key -> a -> t b) -> IntMap a -> t (IntMap b)
-traverseMapWithKey = M.traverseWithKey
-{-# INLINE traverseMapWithKey #-}
 
 -- ---------------------------------------------
 

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -53,10 +53,6 @@ module Data.IntMap.NonEmpty.Internal (
 
   -- * Debug
   valid,
-
-  -- * CPP compatibility
-  lookupMinMap,
-  lookupMaxMap,
 ) where
 
 import Control.Applicative
@@ -711,18 +707,3 @@ insertMinMap = M.insert
 insertMaxMap :: Key -> a -> IntMap a -> IntMap a
 insertMaxMap = M.insert
 {-# INLINEABLE insertMaxMap #-}
-
--- ---------------------------------------------
-
--- | CPP for new functions not in old containers
--- ---------------------------------------------
-
--- | Compatibility layer for 'Data.IntMap.Lazy.lookupMinMap'.
-lookupMinMap :: IntMap a -> Maybe (Key, a)
-lookupMinMap = M.lookupMin
-{-# INLINE lookupMinMap #-}
-
--- | Compatibility layer for 'Data.IntMap.Lazy.lookupMaxMap'.
-lookupMaxMap :: IntMap a -> Maybe (Key, a)
-lookupMaxMap = M.lookupMax
-{-# INLINE lookupMaxMap #-}

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -719,18 +719,10 @@ insertMaxMap = M.insert
 
 -- | Compatibility layer for 'Data.IntMap.Lazy.lookupMinMap'.
 lookupMinMap :: IntMap a -> Maybe (Key, a)
-#if MIN_VERSION_containers(0,5,11)
 lookupMinMap = M.lookupMin
-#else
-lookupMinMap = fmap fst . M.minViewWithKey
-#endif
 {-# INLINE lookupMinMap #-}
 
 -- | Compatibility layer for 'Data.IntMap.Lazy.lookupMaxMap'.
 lookupMaxMap :: IntMap a -> Maybe (Key, a)
-#if MIN_VERSION_containers(0,5,11)
 lookupMaxMap = M.lookupMax
-#else
-lookupMaxMap = fmap fst . M.maxViewWithKey
-#endif
 {-# INLINE lookupMaxMap #-}

--- a/src/Data/IntSet/NonEmpty.hs
+++ b/src/Data/IntSet/NonEmpty.hs
@@ -464,11 +464,11 @@ disjoint ::
   Bool
 disjoint n1@(NEIntSet x1 s1) n2@(NEIntSet x2 s2) = case compare x1 x2 of
   -- x1 is not in n2
-  LT -> s1 `disjointSet` toSet n2
+  LT -> s1 `S.disjoint` toSet n2
   -- k1 and k2 are a part of the result
   EQ -> False
   -- k2 is not in n1
-  GT -> toSet n1 `disjointSet` s2
+  GT -> toSet n1 `S.disjoint` s2
 {-# INLINE disjoint #-}
 
 -- | /O(m*log(n\/m + 1)), m <= n/. Difference of two sets.

--- a/src/Data/IntSet/NonEmpty/Internal.hs
+++ b/src/Data/IntSet/NonEmpty/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
@@ -282,9 +281,5 @@ insertMaxSet = S.insert
 
 -- | Comptability layer for 'Data.IntSet.disjoint'.
 disjointSet :: IntSet -> IntSet -> Bool
-#if MIN_VERSION_containers(0,5,11)
 disjointSet = S.disjoint
-#else
-disjointSet xs = S.null . S.intersection xs
-#endif
 {-# INLINE disjointSet #-}

--- a/src/Data/IntSet/NonEmpty/Internal.hs
+++ b/src/Data/IntSet/NonEmpty/Internal.hs
@@ -28,7 +28,6 @@ module Data.IntSet.NonEmpty.Internal (
   valid,
   insertMinSet,
   insertMaxSet,
-  disjointSet,
 ) where
 
 import Control.DeepSeq
@@ -273,13 +272,3 @@ insertMinSet = S.insert
 insertMaxSet :: Key -> IntSet -> IntSet
 insertMaxSet = S.insert
 {-# INLINEABLE insertMaxSet #-}
-
--- ---------------------------------------------
-
--- | CPP for new functions not in old containers
--- ---------------------------------------------
-
--- | Comptability layer for 'Data.IntSet.disjoint'.
-disjointSet :: IntSet -> IntSet -> Bool
-disjointSet = S.disjoint
-{-# INLINE disjointSet #-}

--- a/src/Data/Sequence/NonEmpty.hs
+++ b/src/Data/Sequence/NonEmpty.hs
@@ -673,7 +673,7 @@ sortBy c (x :<|| xs) =
 sortOn :: Ord b => (a -> b) -> NESeq a -> NESeq a
 sortOn f (x :<|| xs) =
   withNonEmpty (singleton x) (insertOn f x)
-    . sortOnSeq f
+    . Seq.sortOn f
     $ xs
 {-# INLINE sortOn #-}
 
@@ -721,7 +721,7 @@ unstableSortBy c = unsafeFromSeq . Seq.unstableSortBy c . toSeq
 -- TODO: figure out how to make it match 'Data.Sequence.unstableSortBy'
 -- without unsafe wrapping/unwrapping
 unstableSortOn :: Ord b => (a -> b) -> NESeq a -> NESeq a
-unstableSortOn f = unsafeFromSeq . unstableSortOnSeq f . toSeq
+unstableSortOn f = unsafeFromSeq . Seq.unstableSortOn f . toSeq
 -- unstableSortOn f (x :<|| xs) = withNonEmpty (singleton x) (insertOn f x)
 --                              . Seq.unstableSortOn f
 --                              $ xs
@@ -1051,7 +1051,7 @@ zipWith4 f (x :<|| xs) (y :<|| ys) (z :<|| zs) (r :<|| rs) = f x y z r :<|| Seq.
 -- calculating the sequence of pairs and using 'fmap' to extract each
 -- component sequence.
 unzipWith :: (a -> (b, c)) -> NESeq a -> (NESeq b, NESeq c)
-unzipWith f (x :<|| xs) = bimap (y :<||) (z :<||) . unzipWithSeq f $ xs
+unzipWith f (x :<|| xs) = bimap (y :<||) (z :<||) . Seq.unzipWith f $ xs
   where
     ~(y, z) = f x
 {-# NOINLINE [1] unzipWith #-}

--- a/src/Data/Sequence/NonEmpty/Internal.hs
+++ b/src/Data/Sequence/NonEmpty/Internal.hs
@@ -42,10 +42,6 @@ module Data.Sequence.NonEmpty.Internal (
   zip,
   zipWith,
   unzip,
-  sortOnSeq,
-  unstableSortOnSeq,
-  unzipSeq,
-  unzipWithSeq,
 ) where
 
 import Control.Comonad
@@ -402,7 +398,7 @@ zipWith f (x :<|| xs) (y :<|| ys) = f x y :<|| Seq.zipWith f xs ys
 --
 -- See the note about efficiency at 'Data.Sequence.NonEmpty.unzipWith'.
 unzip :: NESeq (a, b) -> (NESeq a, NESeq b)
-unzip ((x, y) :<|| xys) = bimap (x :<||) (y :<||) . unzipSeq $ xys
+unzip ((x, y) :<|| xys) = bimap (x :<||) (y :<||) . Seq.unzip $ xys
 {-# INLINE unzip #-}
 
 instance Semigroup (NESeq a) where
@@ -572,28 +568,3 @@ mfixSeq f = fromFunction (length (f err)) (\k -> fix (\xk -> f xk `index` k))
 
 instance NFData a => NFData (NESeq a) where
   rnf (x :<|| xs) = rnf x `seq` rnf xs
-
--- ---------------------------------------------
-
--- | CPP for new functions not in old containers
--- ---------------------------------------------
-
--- | Compatibility layer for 'Data.Sequence.sortOn'.
-sortOnSeq :: Ord b => (a -> b) -> Seq a -> Seq a
-sortOnSeq = Seq.sortOn
-{-# INLINE sortOnSeq #-}
-
--- | Compatibility layer for 'Data.Sequence.unstableSortOn'.
-unstableSortOnSeq :: Ord b => (a -> b) -> Seq a -> Seq a
-unstableSortOnSeq = Seq.unstableSortOn
-{-# INLINE unstableSortOnSeq #-}
-
--- | Compatibility layer for 'Data.Sequence.unzip'.
-unzipSeq :: Seq (a, b) -> (Seq a, Seq b)
-unzipSeq = Seq.unzip
-{-# INLINE unzipSeq #-}
-
--- | Compatibility layer for 'Data.Sequence.unzipWith'.
-unzipWithSeq :: (a -> (b, c)) -> Seq a -> (Seq b, Seq c)
-unzipWithSeq = Seq.unzipWith
-{-# INLINE unzipWithSeq #-}

--- a/src/Data/Sequence/NonEmpty/Internal.hs
+++ b/src/Data/Sequence/NonEmpty/Internal.hs
@@ -580,45 +580,20 @@ instance NFData a => NFData (NESeq a) where
 
 -- | Compatibility layer for 'Data.Sequence.sortOn'.
 sortOnSeq :: Ord b => (a -> b) -> Seq a -> Seq a
-#if MIN_VERSION_containers(0,5,11)
 sortOnSeq = Seq.sortOn
-#else
-sortOnSeq f = Seq.sortBy (\x y -> f x `compare` f y)
-#endif
 {-# INLINE sortOnSeq #-}
 
 -- | Compatibility layer for 'Data.Sequence.unstableSortOn'.
 unstableSortOnSeq :: Ord b => (a -> b) -> Seq a -> Seq a
-#if MIN_VERSION_containers(0,5,11)
 unstableSortOnSeq = Seq.unstableSortOn
-#else
-unstableSortOnSeq f = Seq.unstableSortBy (\x y -> f x `compare` f y)
-#endif
 {-# INLINE unstableSortOnSeq #-}
 
 -- | Compatibility layer for 'Data.Sequence.unzip'.
 unzipSeq :: Seq (a, b) -> (Seq a, Seq b)
-#if MIN_VERSION_containers(0,5,11)
 unzipSeq = Seq.unzip
 {-# INLINE unzipSeq #-}
-#else
-unzipSeq = \case
-    (x, y) :<| xys -> bimap (x :<|) (y :<|) . unzipSeq $ xys
-    Empty          -> (Empty, Empty)
-{-# INLINABLE unzipSeq #-}
-#endif
 
 -- | Compatibility layer for 'Data.Sequence.unzipWith'.
 unzipWithSeq :: (a -> (b, c)) -> Seq a -> (Seq b, Seq c)
-#if MIN_VERSION_containers(0,5,11)
 unzipWithSeq = Seq.unzipWith
 {-# INLINE unzipWithSeq #-}
-#else
-unzipWithSeq f = go
-  where
-    go = \case
-      x :<| xs -> let ~(y, z) = f x
-                  in  bimap (y :<|) (z :<|) . go $ xs
-      Empty    -> (Empty, Empty)
-{-# INLINABLE unzipWithSeq #-}
-#endif

--- a/src/Data/Set/NonEmpty.hs
+++ b/src/Data/Set/NonEmpty.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -1054,5 +1055,9 @@ combineEq (x :| xs) = go x xs
   where
     go z [] = z :| []
     go z (y : ys)
+#if MIN_VERSION_containers(0,8,0)
+      | z == y = go y ys
+#else
       | z == y = go z ys
+#endif
       | otherwise = z NE.<| go y ys

--- a/src/Data/Set/NonEmpty.hs
+++ b/src/Data/Set/NonEmpty.hs
@@ -338,7 +338,7 @@ powerSet (NESet x s0) = case nonEmptySet p1 of
   where
     -- powerset should never be empty
     p0 :: NESet (Set a)
-    p0@(NESet _ p0s) = forSure $ powerSetSet s0
+    p0@(NESet _ p0s) = forSure $ S.powerSet s0
     p1 :: Set (NESet a)
     p1 = S.mapMonotonic forSure p0s -- only minimal element is empty, so the rest aren't
     forSure =
@@ -463,11 +463,11 @@ disjoint ::
   Bool
 disjoint n1@(NESet x1 s1) n2@(NESet x2 s2) = case compare x1 x2 of
   -- x1 is not in n2
-  LT -> s1 `disjointSet` toSet n2
+  LT -> s1 `S.disjoint` toSet n2
   -- k1 and k2 are a part of the result
   EQ -> False
   -- k2 is not in n1
-  GT -> toSet n1 `disjointSet` s2
+  GT -> toSet n1 `S.disjoint` s2
 {-# INLINE disjoint #-}
 
 -- | /O(m*log(n\/m + 1)), m <= n/. Difference of two sets.
@@ -566,7 +566,7 @@ disjointUnion ::
 disjointUnion (NESet x1 s1) n2 =
   NESet
     (Left x1)
-    (s1 `disjointUnionSet` toSet n2)
+    (s1 `S.disjointUnion` toSet n2)
 {-# INLINE disjointUnion #-}
 
 -- | /O(n)/. Filter all elements that satisfy the predicate.

--- a/src/Data/Set/NonEmpty/Internal.hs
+++ b/src/Data/Set/NonEmpty/Internal.hs
@@ -38,10 +38,6 @@ module Data.Set.NonEmpty.Internal (
   valid,
   insertMinSet,
   insertMaxSet,
-  disjointSet,
-  powerSetSet,
-  disjointUnionSet,
-  cartesianProductSet,
 ) where
 
 import Control.DeepSeq
@@ -499,31 +495,6 @@ insertMaxSet x = \case
   Tip -> S.singleton x
   Bin _ y l r -> balanceR y l (insertMaxSet x r)
 {-# INLINEABLE insertMaxSet #-}
-
--- ---------------------------------------------
-
--- | CPP for new functions not in old containers
--- ---------------------------------------------
-
--- | Comptability layer for 'Data.Set.disjoint'.
-disjointSet :: Ord a => Set a -> Set a -> Bool
-disjointSet = S.disjoint
-{-# INLINE disjointSet #-}
-
--- | Comptability layer for 'Data.Set.powerSet'.
-powerSetSet :: Set a -> Set (Set a)
-powerSetSet = S.powerSet
-{-# INLINE powerSetSet #-}
-
--- | Comptability layer for 'Data.Set.disjointUnion'.
-disjointUnionSet :: Set a -> Set b -> Set (Either a b)
-disjointUnionSet = S.disjointUnion
-{-# INLINE disjointUnionSet #-}
-
--- | Comptability layer for 'Data.Set.cartesianProduct'.
-cartesianProductSet :: Set a -> Set b -> Set (a, b)
-cartesianProductSet = S.cartesianProduct
-{-# INLINE cartesianProductSet #-}
 
 -- ------------------------------------------
 

--- a/src/Data/Set/NonEmpty/Internal.hs
+++ b/src/Data/Set/NonEmpty/Internal.hs
@@ -61,10 +61,6 @@ import qualified Data.Set.Internal as S
 import Text.Read
 import Prelude hiding (Foldable (..))
 
-#if !MIN_VERSION_containers(0,5,11)
-import           Utils.Containers.Internal.StrictPair
-#endif
-
 -- | A non-empty (by construction) set of values @a@.  At least one value
 -- exists in an @'NESet' a@ at all times.
 --
@@ -511,73 +507,22 @@ insertMaxSet x = \case
 
 -- | Comptability layer for 'Data.Set.disjoint'.
 disjointSet :: Ord a => Set a -> Set a -> Bool
-#if MIN_VERSION_containers(0,5,11)
 disjointSet = S.disjoint
-#else
-disjointSet xs = S.null . S.intersection xs
-#endif
 {-# INLINE disjointSet #-}
 
 -- | Comptability layer for 'Data.Set.powerSet'.
 powerSetSet :: Set a -> Set (Set a)
-#if MIN_VERSION_containers(0,5,11)
 powerSetSet = S.powerSet
 {-# INLINE powerSetSet #-}
-#else
-powerSetSet xs0 = insertMinSet S.empty (S.foldr' step' Tip xs0) where
-  step' x pxs = insertMinSet (S.singleton x) (insertMinSet x `S.mapMonotonic` pxs) `glue` pxs
-{-# INLINABLE powerSetSet #-}
-
-minViewSure :: a -> Set a -> Set a -> StrictPair a (Set a)
-minViewSure = go
-  where
-    go x Tip r = x :*: r
-    go x (Bin _ xl ll lr) r =
-      case go xl ll lr of
-        xm :*: l' -> xm :*: balanceR x l' r
-
-maxViewSure :: a -> Set a -> Set a -> StrictPair a (Set a)
-maxViewSure = go
-  where
-    go x l Tip = x :*: l
-    go x l (Bin _ xr rl rr) =
-      case go xr rl rr of
-        xm :*: r' -> xm :*: balanceL x l r'
-
-glue :: Set a -> Set a -> Set a
-glue Tip r = r
-glue l Tip = l
-glue l@(Bin sl xl ll lr) r@(Bin sr xr rl rr)
-  | sl > sr = let !(m :*: l') = maxViewSure xl ll lr in balanceR m l' r
-  | otherwise = let !(m :*: r') = minViewSure xr rl rr in balanceL m l r'
-#endif
 
 -- | Comptability layer for 'Data.Set.disjointUnion'.
 disjointUnionSet :: Set a -> Set b -> Set (Either a b)
-#if MIN_VERSION_containers(0,5,11)
 disjointUnionSet = S.disjointUnion
-#else
-disjointUnionSet as bs = S.merge (S.mapMonotonic Left as) (S.mapMonotonic Right bs)
-#endif
 {-# INLINE disjointUnionSet #-}
 
 -- | Comptability layer for 'Data.Set.cartesianProduct'.
 cartesianProductSet :: Set a -> Set b -> Set (a, b)
-#if MIN_VERSION_containers(0,5,11)
 cartesianProductSet = S.cartesianProduct
-#else
-cartesianProductSet as bs =
-  getMergeSet $ foldMap (\a -> MergeSet $ S.mapMonotonic (a, ) bs) as
-
-newtype MergeSet a = MergeSet { getMergeSet :: Set a }
-
-instance Semigroup (MergeSet a) where
-    MergeSet xs <> MergeSet ys = MergeSet (S.merge xs ys)
-
-instance Monoid (MergeSet a) where
-    mempty = MergeSet S.empty
-    mappend = (<>)
-#endif
 {-# INLINE cartesianProductSet #-}
 
 -- ------------------------------------------

--- a/test/Tests/IntMap.hs
+++ b/test/Tests/IntMap.hs
@@ -16,6 +16,7 @@ import qualified Data.IntMap.NonEmpty.Internal as NEM
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup.Foldable
+import Data.Semigroup.Traversable
 import Data.Text (Text)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -479,45 +480,43 @@ prop_mapWithKey_rules_map =
     (\f g xs -> M.mapWithKey f (M.map g xs))
     (\f g xs -> NEM.mapWithKey f (NEM.map g xs))
 
--- | These intentionally do not match, because Foldable for IntMap is
--- inconsistent
--- prop_traverseWithKey1 :: Property
--- prop_traverseWithKey1 = ttProp (gf1 valGen :?> GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
---     (\f -> M.traverseWithKey    (\k -> (`More` Done (f . (k,)))))
---     (\f -> NEM.traverseWithKey1 (\k -> (`More` Done (f . (k,)))))
+prop_traverseWithKey1 :: Property
+prop_traverseWithKey1 = ttProp (gf1 valGen :?> GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
+    (\f -> M.traverseWithKey    (\k -> (`More` Done (f . (k,)))))
+    (\f -> NEM.traverseWithKey1 (\k -> (`More` Done (f . (k,)))))
 
--- prop_traverseWithKey :: Property
--- prop_traverseWithKey = ttProp (gf1 valGen :?> GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
---     (\f -> M.traverseWithKey   (\k -> (`More` Done (f . (k,)))))
---     (\f -> NEM.traverseWithKey (\k -> (`More` Done (f . (k,)))))
+prop_traverseWithKey :: Property
+prop_traverseWithKey = ttProp (gf1 valGen :?> GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
+    (\f -> M.traverseWithKey   (\k -> (`More` Done (f . (k,)))))
+    (\f -> NEM.traverseWithKey (\k -> (`More` Done (f . (k,)))))
 
--- prop_sequence1 :: Property
--- prop_sequence1 = ttProp (GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
---     (sequenceA . fmap (`More` Done id))
---     (sequence1 . fmap (`More` Done id))
+prop_sequence1 :: Property
+prop_sequence1 = ttProp (GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
+    (sequenceA . fmap (`More` Done id))
+    (sequence1 . fmap (`More` Done id))
 
--- prop_sequenceA :: Property
--- prop_sequenceA = ttProp (GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
---     (sequenceA . fmap (`More` Done id))
---     (sequenceA . fmap (`More` Done id))
+prop_sequenceA :: Property
+prop_sequenceA = ttProp (GTNEIntMap :-> TTBazaar GTVal TTNEIntMap TTVal)
+    (sequenceA . fmap (`More` Done id))
+    (sequenceA . fmap (`More` Done id))
 
--- prop_mapAccumWithKey :: Property
--- prop_mapAccumWithKey = ttProp  ( gf3 ((,) <$> valGen <*> valGen)
---                              :?> GTOther valGen
---                              :-> GTNEIntMap
---                              :-> TTOther :*: TTNEIntMap
---                                )
---     M.mapAccumWithKey
---     NEM.mapAccumWithKey
+prop_mapAccumWithKey :: Property
+prop_mapAccumWithKey = ttProp  ( gf3 ((,) <$> valGen <*> valGen)
+                             :?> GTOther valGen
+                             :-> GTNEIntMap
+                             :-> TTOther :*: TTNEIntMap
+                               )
+    M.mapAccumWithKey
+    NEM.mapAccumWithKey
 
--- prop_mapAccumRWithKey :: Property
--- prop_mapAccumRWithKey = ttProp  ( gf3 ((,) <$> valGen <*> valGen)
---                               :?> GTOther valGen
---                               :-> GTNEIntMap
---                               :-> TTOther :*: TTNEIntMap
---                                 )
---     M.mapAccumRWithKey
---     NEM.mapAccumRWithKey
+prop_mapAccumRWithKey :: Property
+prop_mapAccumRWithKey = ttProp  ( gf3 ((,) <$> valGen <*> valGen)
+                              :?> GTOther valGen
+                              :-> GTNEIntMap
+                              :-> TTOther :*: TTNEIntMap
+                                )
+    M.mapAccumRWithKey
+    NEM.mapAccumRWithKey
 
 prop_mapKeys :: Property
 prop_mapKeys =

--- a/test/Tests/IntMap.hs
+++ b/test/Tests/IntMap.hs
@@ -12,7 +12,6 @@ import Data.Functor.Alt
 import Data.Functor.Identity
 import qualified Data.IntMap as M
 import qualified Data.IntMap.NonEmpty as NEM
-import qualified Data.IntMap.NonEmpty.Internal as NEM
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup.Foldable
@@ -59,7 +58,7 @@ prop_valid_insertMapMin :: Property
 prop_valid_insertMapMin = property $ do
   n <- forAll $ do
     m <- intMapGen
-    let k = maybe 0 (subtract 1 . fst) $ NEM.lookupMinMap m
+    let k = maybe 0 (subtract 1 . fst) $ M.lookupMin m
     v <- valGen
     pure $ NEM.insertMapMin k v m
   assert $ NEM.valid n
@@ -68,7 +67,7 @@ prop_valid_insertMapMax :: Property
 prop_valid_insertMapMax = property $ do
   n <- forAll $ do
     m <- intMapGen
-    let k = maybe 0 ((+ 1) . fst) $ NEM.lookupMaxMap m
+    let k = maybe 0 ((+ 1) . fst) $ M.lookupMax m
     v <- valGen
     pure $ NEM.insertMapMax k v m
   assert $ NEM.valid n

--- a/test/Tests/IntSet.hs
+++ b/test/Tests/IntSet.hs
@@ -5,7 +5,6 @@ module Tests.IntSet (intSetTests) where
 import Data.Functor.Identity
 import qualified Data.IntSet as S
 import qualified Data.IntSet.NonEmpty as NES
-import qualified Data.IntSet.NonEmpty.Internal as NES
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup.Foldable
@@ -210,7 +209,7 @@ prop_disjoint :: Property
 prop_disjoint =
   ttProp
     (GTNEIntSet :-> GTNEIntSet :-> TTOther)
-    NES.disjointSet
+    S.disjoint
     NES.disjoint
 
 prop_union :: Property

--- a/test/Tests/Sequence.hs
+++ b/test/Tests/Sequence.hs
@@ -18,7 +18,6 @@ import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
 import Data.Sequence.NonEmpty (NESeq (..))
 import qualified Data.Sequence.NonEmpty as NESeq
-import qualified Data.Sequence.NonEmpty.Internal as NESeq
 import Data.Tuple
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -369,7 +368,7 @@ prop_sortOn :: Property
 prop_sortOn =
   ttProp
     (gf1 valGen :?> GTNESeq :-> TTNESeq)
-    NESeq.sortOnSeq
+    Seq.sortOn
     NESeq.sortOn
 
 prop_unstableSort :: Property
@@ -390,7 +389,7 @@ prop_unstableSortOn :: Property
 prop_unstableSortOn =
   ttProp
     (gf1 valGen :?> GTNESeq :-> TTNESeq)
-    NESeq.unstableSortOnSeq
+    Seq.unstableSortOn
     NESeq.unstableSortOn
 
 prop_lookup :: Property
@@ -621,7 +620,7 @@ prop_unzip :: Property
 prop_unzip =
   ttProp
     (GTNESeq :-> GTNESeq :-> TTNESeq :*: TTNESeq)
-    (\xs -> NESeq.unzipSeq . Seq.zip xs)
+    (\xs -> Seq.unzip . Seq.zip xs)
     (\xs -> NESeq.unzip . NESeq.zip xs)
 
 prop_unzipWith :: Property
@@ -632,7 +631,7 @@ prop_unzipWith =
         :-> TTNESeq
         :*: TTNESeq
     )
-    NESeq.unzipWithSeq
+    Seq.unzipWith
     NESeq.unzipWith
 
 prop_liftA2 :: Property

--- a/test/Tests/Set.hs
+++ b/test/Tests/Set.hs
@@ -142,7 +142,7 @@ prop_powerSet :: Property
 prop_powerSet =
   ttProp
     (GTNESet :-> TTNEList TTNESet)
-    (S.toList . S.drop 1 . NES.powerSetSet)
+    (S.toList . S.drop 1 . S.powerSet)
     (NES.toList . NES.powerSet)
 
 prop_insert :: Property
@@ -226,7 +226,7 @@ prop_disjoint :: Property
 prop_disjoint =
   ttProp
     (GTNESet :-> GTNESet :-> TTOther)
-    NES.disjointSet
+    S.disjoint
     NES.disjoint
 
 prop_union :: Property
@@ -261,14 +261,14 @@ prop_cartesianProduct :: Property
 prop_cartesianProduct =
   ttProp
     (GTNESet :-> GTNESet :-> TTNEList (TTKey :*: TTKey))
-    (\xs -> S.toList . NES.cartesianProductSet xs)
+    (\xs -> S.toList . S.cartesianProduct xs)
     (\xs -> NES.toList . NES.cartesianProduct xs)
 
 prop_disjointUnion :: Property
 prop_disjointUnion =
   ttProp
     (GTNESet :-> GTNESet :-> TTNEList (TTEither TTKey TTKey))
-    (\xs -> S.toList . NES.disjointUnionSet xs)
+    (\xs -> S.toList . S.disjointUnion xs)
     (\xs -> NES.toList . NES.disjointUnion xs)
 
 prop_filter :: Property


### PR DESCRIPTION
This PR adds support for `containers` version `0.8`.

It:

1. Removes the custom implementation of `Data.IntMap.NonEmpty.Internal.traverseMapWithKey` and updates call sites to use `Data.IntMap.traverseWithKey` instead, which correctly traverses in ascending order of keys for `containers >= 0.6.3.1` (see below.) 

1. Adjusts `Data.Set.NonEmpty.combineEq` so that:
    - for `containers  < 0.8`: `combineEq` chooses the **_first_** occurrence of each duplicated element (consistent with behaviour of `containers  < 0.8`).
    - for `containers >= 0.8`: `combineEq` chooses the **_last_** occurrence of each duplicated element (consistent with behaviour of `containers >= 0.8`).

    This is to account for a [change in behaviour](https://github.com/mstksg/nonempty-containers/issues/17#issuecomment-2692642276) of `Data.Set.from{Asc,Desc}List` between `containers-0.7` and `containers-0.8`:
    - for `containers <  0.8`: `Set.from{Asc,Desc}List` chooses the **_first_** occurrence of any duplicated element.
    - for `containers >= 0.8`: `Set.from{Asc,Desc}List` chooses the **_last_** occurrence of any duplicated element.

1. Updates both lower and upper bounds for `containers` to reflect the set of versions for which all tests pass (`containers >= 0.6.3.1 && < 0.9`)

1. Removes the compatibility layer for `containers < 0.5.11`. Assuming the package is only buildable for `containers >= 0.6.3.1`, then it should be safe to remove this layer.

### Testing

I have confirmed that the test suite passes for all versions of `containers` between `0.6.3.1` and `0.8` (inclusively):
- ✅ `0.8`
- ✅ `0.7`
- ✅ `0.6.8`
- ✅ `0.6.7`
- ✅ `0.6.6`
- ✅ `0.6.5.1`
- ✅ `0.6.4.1`
- ✅ `0.6.3.1` (released in `2020-07-14`)

The test suite fails for the following older versions of `containers`:
- 💥 `0.6.2.1` (released in `2019-06-24`)
- 💥 `0.6.1.1`
- 💥 `0.6.0.1`
- 💥  `0.5.11.0`

Tests that fail with older versions of `containers`:
- `Tests.IntMap.mapAccumWithKey`
- `Tests.IntMap.sequenceA`
- `Tests.IntMap.sequence1`
- `Tests.IntMap.traverseWithKey`
- `Tests.IntMap.traverseWithKey1`