### PR TITLE
Add IsList instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 0.3.6.0
+---------------
+*   Add `IsList` instances for `-XOverloadedLists`.
+
 Version 0.3.5.0
 ---------------
 

--- a/nonempty-containers.cabal
+++ b/nonempty-containers.cabal
@@ -5,7 +5,7 @@ cabal-version:      1.12
 -- see: https://github.com/sol/hpack
 
 name:               nonempty-containers
-version:            0.3.5.0
+version:            0.3.6.0
 synopsis:           Non-empty variants of containers data types, with full API
 description:
   Efficient and optimized non-empty versions of types from /containers/.

--- a/src/Data/IntMap/NonEmpty/Internal.hs
+++ b/src/Data/IntMap/NonEmpty/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -76,6 +77,7 @@ import Data.Semigroup
 import Data.Semigroup.Foldable (Foldable1 (fold1))
 import qualified Data.Semigroup.Foldable as F1
 import Data.Semigroup.Traversable (Traversable1 (..))
+import qualified GHC.Exts as Exts
 import Text.Read
 import Prelude hiding (Foldable (..), map)
 
@@ -135,6 +137,15 @@ instance Ord a => Ord (NEIntMap a) where
   (>) = (>) `on` toList
   (<=) = (<=) `on` toList
   (>=) = (>=) `on` toList
+
+-- | @since 0.3.6.0
+instance Exts.IsList (NEIntMap a) where
+  type Item (NEIntMap a) = (Key, a)
+
+  fromList (a:as) = fromList (a :| as)
+  fromList [] = errorWithoutStackTrace "Data.IntMap.NonEmpty.fromList: empty list"
+
+  toList = F.toList . toList
 
 instance Eq1 NEIntMap where
   liftEq eq m1 m2 =

--- a/src/Data/IntSet/NonEmpty/Internal.hs
+++ b/src/Data/IntSet/NonEmpty/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -42,6 +43,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup
 import Data.Semigroup.Foldable (Foldable1)
 import qualified Data.Semigroup.Foldable as F1
+import qualified GHC.Exts as Exts
 import Text.Read
 
 -- | A non-empty (by construction) set of integers.  At least one value
@@ -114,6 +116,15 @@ instance Read NEIntSet where
 
 instance NFData NEIntSet where
   rnf (NEIntSet x s) = rnf x `seq` rnf s
+
+-- | @since 0.3.6.0
+instance Exts.IsList NEIntSet where
+  type Item NEIntSet = Key
+
+  fromList (a:as) = fromList (a :| as)
+  fromList [] = errorWithoutStackTrace "Data.IntSet.NonEmpty.fromList: empty list"
+
+  toList = F.toList . toList
 
 -- Data instance code from Data.IntSet.Internal
 --

--- a/src/Data/Map/NonEmpty/Internal.hs
+++ b/src/Data/Map/NonEmpty/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -75,6 +76,7 @@ import Data.Semigroup
 import Data.Semigroup.Foldable (Foldable1 (fold1))
 import qualified Data.Semigroup.Foldable as F1
 import Data.Semigroup.Traversable (Traversable1 (..))
+import qualified GHC.Exts as Exts
 import Text.Read
 import Prelude hiding (Foldable (..), map)
 
@@ -180,6 +182,16 @@ instance (Show k, Show a) => Show (NEMap k a) where
 
 instance (NFData k, NFData a) => NFData (NEMap k a) where
   rnf (NEMap k v a) = rnf k `seq` rnf v `seq` rnf a
+
+-- | @since 0.3.6.0
+instance (Ord k) => Exts.IsList (NEMap k a) where
+  type Item (NEMap k a) = (k, a)
+
+  fromList (a:as) = fromList (a :| as)
+  fromList [] = errorWithoutStackTrace "Data.Map.NonEmpty.fromList: empty list"
+
+  toList = F.toList . toList
+
 
 -- Data instance code from Data.Map.Internal
 --

--- a/src/Data/Sequence/NonEmpty/Internal.hs
+++ b/src/Data/Sequence/NonEmpty/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -65,6 +66,7 @@ import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
 import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
+import qualified GHC.Exts as Exts
 import Text.Read
 import Prelude hiding (length, map, replicate, unzip, zip, zipWith)
 
@@ -169,6 +171,15 @@ instance Eq a => Eq (NESeq a) where
 
 instance Ord a => Ord (NESeq a) where
   compare xs ys = compare (F.toList xs) (F.toList ys)
+
+-- | @since 0.3.6.0
+instance Exts.IsList (NESeq a) where
+  type Item (NESeq a) = a
+
+  fromList (a:as) = fromList (a :| as)
+  fromList [] = errorWithoutStackTrace "Data.Sequence.NonEmpty.fromList: empty list"
+
+  toList = F.toList
 
 instance Show1 NESeq where
   liftShowsPrec sp sl d m =

--- a/src/Data/Set/NonEmpty/Internal.hs
+++ b/src/Data/Set/NonEmpty/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
@@ -53,6 +54,7 @@ import qualified Data.Semigroup.Foldable as F1
 import qualified Data.Set as S
 import Data.Set.Internal (Set (..))
 import qualified Data.Set.Internal as S
+import qualified GHC.Exts as Exts
 import Text.Read
 import Prelude hiding (Foldable (..))
 
@@ -123,6 +125,15 @@ instance (Read a, Ord a) => Read (NESet a) where
     return (fromList xs)
 
   readListPrec = readListPrecDefault
+
+-- | @since 0.3.6.0
+instance (Ord a) => Exts.IsList (NESet a) where
+  type Item (NESet a) = a
+
+  fromList (a:as) = fromList (a :| as)
+  fromList [] = errorWithoutStackTrace "Data.Set.NonEmpty.fromList: empty list"
+
+  toList = F.toList
 
 instance Eq1 NESet where
   liftEq eq m n =

--- a/test/Tests/IntMap.hs
+++ b/test/Tests/IntMap.hs
@@ -17,6 +17,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
 import Data.Text (Text)
+import qualified GHC.Exts as Exts
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -185,6 +186,18 @@ prop_fromListWithKey =
     (gf3 valGen :?> GTNEList Nothing (GTIntKey :&: GTVal) :-> TTNEIntMap)
     M.fromListWithKey
     NEM.fromListWithKey
+
+prop_toFromOverloadedList :: Property
+prop_toFromOverloadedList =
+  property $ do
+    s <- forAll neIntMapGen
+    s === Exts.fromList (Exts.toList s)
+
+prop_fromToOverloadedList :: Property
+prop_fromToOverloadedList =
+  property $ do
+    l <- forAll neIntTextListUniqGen
+    l === Exts.toList (Exts.fromList @(NEM.NEIntMap Text) l)
 
 prop_insert :: Property
 prop_insert =

--- a/test/Tests/IntSet.hs
+++ b/test/Tests/IntSet.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Tests.IntSet (intSetTests) where
 
@@ -8,6 +9,8 @@ import qualified Data.IntSet.NonEmpty as NES
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup.Foldable
+import Data.Text (Text)
+import qualified GHC.Exts as Exts
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -127,6 +130,18 @@ prop_fromList =
     (GTNEList Nothing GTIntKey :-> TTNEIntSet)
     S.fromList
     NES.fromList
+
+prop_toFromOverloadedList :: Property
+prop_toFromOverloadedList =
+  property $ do
+    s <- forAll neIntSetGen
+    s === Exts.fromList (Exts.toList s)
+
+prop_fromToOverloadedList :: Property
+prop_fromToOverloadedList =
+  property $ do
+    l <- forAll neIntListUniqGen
+    l === Exts.toList (Exts.fromList @(NES.NEIntSet) l)
 
 prop_insert :: Property
 prop_insert =

--- a/test/Tests/Map.hs
+++ b/test/Tests/Map.hs
@@ -17,6 +17,7 @@ import qualified Data.Map.NonEmpty.Internal as NEM
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
 import Data.Text (Text)
+import qualified GHC.Exts as Exts
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -209,6 +210,18 @@ prop_fromListWithKey =
     (gf3 valGen :?> GTNEList Nothing (GTKey :&: GTVal) :-> TTNEMap)
     M.fromListWithKey
     NEM.fromListWithKey
+
+prop_toFromOverloadedList :: Property
+prop_toFromOverloadedList =
+  property $ do
+    s <- forAll neMapGen
+    s === Exts.fromList (Exts.toList s)
+
+prop_fromToOverloadedList :: Property
+prop_fromToOverloadedList =
+  property $ do
+    l <- forAll neKeyListUniqGen
+    l === Exts.toList (Exts.fromList @(NEM.NEMap KeyType Text) l)
 
 prop_insert :: Property
 prop_insert =

--- a/test/Tests/Sequence.hs
+++ b/test/Tests/Sequence.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TupleSections #-}
 
 module Tests.Sequence (sequenceTests) where
@@ -18,7 +19,9 @@ import Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
 import Data.Sequence.NonEmpty (NESeq (..))
 import qualified Data.Sequence.NonEmpty as NESeq
+import Data.Text (Text)
 import Data.Tuple
+import qualified GHC.Exts as Exts
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import Test.Tasty
@@ -121,6 +124,18 @@ prop_fromList =
     (GTNEList Nothing GTVal :-> TTNESeq)
     Seq.fromList
     NESeq.fromList
+
+prop_toFromOverloadedList :: Property
+prop_toFromOverloadedList =
+  property $ do
+    s <- forAll neSeqGen
+    s === Exts.fromList (Exts.toList s)
+
+prop_fromToOverloadedList :: Property
+prop_fromToOverloadedList =
+  property $ do
+    l <- forAll neListGen
+    l === Exts.toList (Exts.fromList @(NESeq.NESeq Text) l)
 
 prop_fromFunction :: Property
 prop_fromFunction =

--- a/test/Tests/Set.hs
+++ b/test/Tests/Set.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Tests.Set (setTests) where
 
 import Data.Foldable
 import Data.Functor.Identity
+import Data.Text (Text)
 import Data.Semigroup.Foldable
 import qualified Data.Set as S
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Set.NonEmpty.Internal as NES
+import qualified GHC.Exts as Exts
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -137,6 +140,18 @@ prop_fromList =
     (GTNEList Nothing GTKey :-> TTNESet)
     S.fromList
     NES.fromList
+
+prop_toFromOverloadedList :: Property
+prop_toFromOverloadedList =
+  property $ do
+    s <- forAll neSetGen
+    s === Exts.fromList (Exts.toList s)
+
+prop_fromToOverloadedList :: Property
+prop_fromToOverloadedList =
+  property $ do
+    l <- forAll neListUniqGen
+    l === Exts.toList (Exts.fromList @(NES.NESet Text) l)
 
 prop_powerSet :: Property
 prop_powerSet =

--- a/test/Tests/Util.hs
+++ b/test/Tests/Util.hs
@@ -47,6 +47,11 @@ module Tests.Util (
   neIntSetGen,
   seqGen,
   neSeqGen,
+  neListGen,
+  neListUniqGen,
+  neIntListUniqGen,
+  neIntTextListUniqGen,
+  neKeyListUniqGen,
 ) where
 
 import Control.Applicative
@@ -609,6 +614,21 @@ seqGen = Gen.seq mapSize valGen
 
 neSeqGen :: (MonadGen m, GenBase m ~ Identity) => m (NESeq Text)
 neSeqGen = Gen.just $ NESeq.nonEmptySeq <$> seqGen
+
+neListGen :: (MonadGen m) => m [Text]
+neListGen = Gen.list mapSize valGen
+
+neListUniqGen :: (MonadGen m) => m [Text]
+neListUniqGen = S.toList . S.fromList <$> neListGen
+
+neIntListUniqGen :: (MonadGen m) => m [Int]
+neIntListUniqGen = IS.toList <$> intSetGen
+
+neIntTextListUniqGen :: (MonadGen m, GenBase m ~ Identity) => m [(Int, Text)]
+neIntTextListUniqGen = toList . NEIM.toList <$> neIntMapGen
+
+neKeyListUniqGen :: (MonadGen m, GenBase m ~ Identity) => m [(KeyType, Text)]
+neKeyListUniqGen = toList . NEM.toList <$> neMapGen
 
 -- ---------------------
 -- Orphans


### PR DESCRIPTION
Resolves https://github.com/mstksg/nonempty-containers/issues/7.

As that issue notes, this is unsafe, though imo it is worth the convenience in some situations e.g. literal test values. The implementation is based on the `NonEmpty` version in [base](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-List-NonEmpty.html).

```haskell
instance IsList (NonEmpty a) where
  type Item (NonEmpty a) = a

  fromList (a:as) = a :| as
  fromList [] = errorWithoutStackTrace "NonEmpty.fromList: empty list"

  toList ~(a :| as) = a : as
```